### PR TITLE
Added `exists`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@
 
     chown :: forall eff. FilePath -> Number -> Number -> Eff (err :: Exception, fs :: FS | eff) Unit
 
+    exists :: forall eff. FilePath -> Eff (fs :: FS | eff) Boolean
+
     link :: forall eff. FilePath -> FilePath -> Eff (err :: Exception, fs :: FS | eff) Unit
 
     mkdir :: forall eff. FilePath -> Eff (err :: Exception, fs :: FS | eff) Unit

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -21,6 +21,7 @@ module Node.FS.Sync
   , writeTextFile
   , appendFile
   , appendTextFile
+  , exists
   ) where
 
 import Control.Monad.Eff
@@ -52,6 +53,7 @@ foreign import fs "var fs = require('fs');" ::
   , readFileSync :: forall a opts. Fn2 FilePath { | opts } a
   , writeFileSync :: forall a opts. Fn3 FilePath a { | opts } Unit
   , appendFileSync :: forall a opts. Fn3 FilePath a { | opts } Unit
+  , existsSync :: Fn1 FilePath Boolean
   }
 
 foreign import mkEff
@@ -278,3 +280,11 @@ appendTextFile :: forall eff. Encoding
 
 appendTextFile encoding file buff = mkEff $ \_ -> runFn3
   fs.appendFileSync file buff { encoding: show encoding }
+
+-- |
+-- Check if the path exists.
+--
+exists :: forall eff. FilePath
+                   -> Eff (fs :: FS | eff) Boolean
+exists file = mkEff $ \_ -> runFn1
+  fs.existsSync file


### PR DESCRIPTION
I'd like to add [exists](http://nodejs.org/api/fs.html#fs_fs_exists_path_callback) to the `Async` version as well. However, this is one of the few(only?) function that actually doesn't throw an error as its first argument. So, implementing it means we have a couple of options:
1. Wrap it into a function that does nothing with its first `Error` argument.
2. Drop into the ffi and handle this one case.

The first one seems like a mismatch between the underlying api and this version. 
The second one seems a bit unnecessary of a thing to have to do for one specific function, but it brought up some questions in IRC. In specific, how can this function remove the effects safely?: https://github.com/purescript-contrib/purescript-node-fs/blob/master/src/Node/FS/Async.purs#L43-L52 I might be just missing somehting, but it doesn't seem safe.

I don't really care which way is prefered. I really only want the `Sync` version anyway. So, just let me know which to go with and I'll implement it.
