### PR TITLE
Use proper type for file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ chown :: forall eff. FilePath -> Number -> Number -> Callback eff Unit -> Eff (f
 #### `chmod`
 
 ``` purescript
-chmod :: forall eff. FilePath -> Number -> Callback eff Unit -> Eff (fs :: FS | eff) Unit
+chmod :: forall eff. FilePath -> Perms -> Callback eff Unit -> Eff (fs :: FS | eff) Unit
 ```
 
 #### `stat`
@@ -121,7 +121,7 @@ mkdir :: forall eff. FilePath -> Callback eff Unit -> Eff (fs :: FS | eff) Unit
 #### `mkdir'`
 
 ``` purescript
-mkdir' :: forall eff. FilePath -> Number -> Callback eff Unit -> Eff (fs :: FS | eff) Unit
+mkdir' :: forall eff. FilePath -> Perms -> Callback eff Unit -> Eff (fs :: FS | eff) Unit
 ```
 
 #### `readdir`
@@ -177,6 +177,51 @@ appendTextFile :: forall eff. Encoding -> FilePath -> String -> Callback eff Uni
 ``` purescript
 exists :: forall eff. FilePath -> (Boolean -> Eff eff Unit) -> Eff (fs :: FS | eff) Unit
 ```
+
+
+## Module Node.FS.Perms
+
+#### `Perms`
+
+``` purescript
+data Perms
+```
+
+
+#### `permsFromString`
+
+``` purescript
+permsFromString :: String -> Maybe Perms
+```
+
+
+#### `permsToString`
+
+``` purescript
+permsToString :: Perms -> String
+```
+
+
+#### `permsToNum`
+
+``` purescript
+permsToNum :: Perms -> Number
+```
+
+
+#### `showPerm`
+
+``` purescript
+instance showPerm :: Show Perm
+```
+
+
+#### `showPerms`
+
+``` purescript
+instance showPerms :: Show Perms
+```
+
 
 
 ## Module Node.FS.Stats
@@ -357,7 +402,7 @@ chown :: forall eff. FilePath -> Number -> Number -> Eff (err :: Exception, fs :
 #### `chmod`
 
 ``` purescript
-chmod :: forall eff. FilePath -> Number -> Eff (err :: Exception, fs :: FS | eff) Unit
+chmod :: forall eff. FilePath -> Perms -> Eff (err :: Exception, fs :: FS | eff) Unit
 ```
 
 #### `stat`
@@ -417,7 +462,7 @@ mkdir :: forall eff. FilePath -> Eff (err :: Exception, fs :: FS | eff) Unit
 #### `mkdir'`
 
 ``` purescript
-mkdir' :: forall eff. FilePath -> Number -> Eff (err :: Exception, fs :: FS | eff) Unit
+mkdir' :: forall eff. FilePath -> Perms -> Eff (err :: Exception, fs :: FS | eff) Unit
 ```
 
 #### `readdir`

--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "purescript-datetime": "~0.5.0",
     "purescript-exceptions": "~0.2.1",
     "purescript-strings": "~0.4.5",
-    "purescript-globals": "~0.1.6"
+    "purescript-globals": "~0.1.6",
+    "purescript-integers": "~0.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,8 @@
     "purescript-node-buffer": "~0.0.1",
     "purescript-node-path": "~0.3.0",
     "purescript-datetime": "~0.5.0",
-    "purescript-exceptions": "~0.2.1"
+    "purescript-exceptions": "~0.2.1",
+    "purescript-strings": "~0.4.5",
+    "purescript-globals": "~0.1.6"
   }
 }

--- a/src/Node/FS/Async.purs
+++ b/src/Node/FS/Async.purs
@@ -227,7 +227,7 @@ mkdir :: forall eff. FilePath
                   -> Callback eff Unit
                   -> Eff (fs :: FS | eff) Unit
 
-mkdir = flip mkdir' (fromJust $ permsFromString "777")
+mkdir = flip mkdir' $ mkPerms (r <> w <> x) (r <> w <> x) (r <> w <> x)
 
 -- |
 -- Makes a new directory with the specified permissions.

--- a/src/Node/FS/Async.purs
+++ b/src/Node/FS/Async.purs
@@ -63,7 +63,7 @@ foreign import fs "var fs = require('fs');" ::
   { rename :: Fn3 FilePath FilePath (JSCallback Unit) Unit
   , truncate :: Fn3 FilePath Number (JSCallback Unit) Unit
   , chown :: Fn4 FilePath Number Number (JSCallback Unit) Unit
-  , chmod :: Fn3 FilePath Number (JSCallback Unit) Unit
+  , chmod :: Fn3 FilePath String (JSCallback Unit) Unit
   , stat :: Fn2 FilePath (JSCallback StatsObj) Unit
   , link :: Fn3 FilePath FilePath (JSCallback Unit) Unit
   , symlink :: Fn4 FilePath FilePath String (JSCallback Unit) Unit
@@ -128,12 +128,12 @@ chown file uid gid cb = mkEff $ \_ -> runFn4
 -- Changes the permissions of a file.
 --
 chmod :: forall eff. FilePath
-                  -> Number
+                  -> Perms
                   -> Callback eff Unit
                   -> Eff (fs :: FS | eff) Unit
 
-chmod file mode cb = mkEff $ \_ -> runFn3
-  fs.chmod file mode (handleCallback cb)
+chmod file perms cb = mkEff $ \_ -> runFn3
+  fs.chmod file (permsToString perms) (handleCallback cb)
 
 -- |
 -- Gets file statistics.

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -2,7 +2,6 @@ module Node.FS.Perms
   ( permsFromString
   , permsToString
   , permsToNum
-  , Perm()
   , Perms()
   ) where
 

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -59,8 +59,6 @@ permsToString (Perms { u = u, g = g, o = o }) =
   ++ permToString g
   ++ permToString o
 
-type Radix = Number
-
 permsToNum :: Perms -> Number
 permsToNum p = readInt 8 $ permsToString p
 

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -41,14 +41,14 @@ permsFromString = _perms <<< toCharArray
 permFromChar :: Char -> Maybe Perm
 permFromChar = _perm <<< charString
   where
-    _perm "0" = Just $ mkPerm false false false
-    _perm "1" = Just $ mkPerm false false true
-    _perm "2" = Just $ mkPerm false true  false
-    _perm "3" = Just $ mkPerm false true  true
-    _perm "4" = Just $ mkPerm true  false false
-    _perm "5" = Just $ mkPerm true  false true
-    _perm "6" = Just $ mkPerm true  true  false
-    _perm "7" = Just $ mkPerm true  true  true
+    _perm "0" = Just $ none
+    _perm "1" = Just $ x
+    _perm "2" = Just $ w
+    _perm "3" = Just $ w <> x
+    _perm "4" = Just $ r
+    _perm "5" = Just $ r <> x
+    _perm "6" = Just $ r <> w
+    _perm "7" = Just $ r <> w <> x
     _perm _   = Nothing
 
 mkPerm :: Boolean -> Boolean -> Boolean -> Perm

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -1,7 +1,7 @@
 module Node.FS.Perms
   ( permsFromString
   , permsToString
-  , permsToNum
+  , permsToInt
   , none
   , r
   , w
@@ -16,6 +16,7 @@ import Data.Maybe (Maybe(..))
 import Data.Char (Char(), charString)
 import Data.String (toCharArray)
 import Data.Function
+import Data.Int (Int(), fromNumber, toNumber)
 
 newtype Perm = Perm { r :: Boolean, w :: Boolean, x :: Boolean }
 newtype Perms = Perms { u :: Perm, g :: Perm, o :: Perm }
@@ -57,14 +58,14 @@ mkPerm r w x = Perm { r: r, w: w, x: x }
 mkPerms :: Perm -> Perm -> Perm -> Perms
 mkPerms u g o = Perms { u: u, g: g, o: o }
 
-permToNum :: Perm -> Number
-permToNum (Perm { r = r, w = w, x = x }) =
+permToInt :: Perm -> Int
+permToInt (Perm { r = r, w = w, x = x }) = fromNumber $
     (if r then 4 else 0)
   + (if w then 2 else 0)
   + (if x then 1 else 0)
 
 permToString :: Perm -> String
-permToString = show <<< permToNum
+permToString = show <<< toNumber <<< permToInt
 
 permsToString :: Perms -> String
 permsToString (Perms { u = u, g = g, o = o }) =
@@ -73,8 +74,8 @@ permsToString (Perms { u = u, g = g, o = o }) =
   ++ permToString g
   ++ permToString o
 
-permsToNum :: Perms -> Number
-permsToNum p = readInt 8 $ permsToString p
+permsToInt :: Perms -> Int
+permsToInt p = fromNumber $ readInt 8 $ permsToString p
 
 instance showPerm :: Show Perm where
   show (Perm { r = r, w = w, x = x }) =

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -15,7 +15,6 @@ import Global (readInt)
 import Data.Maybe (Maybe(..))
 import Data.Char (Char(), charString)
 import Data.String (toCharArray)
-import Data.Function
 import Data.Int (Int(), fromNumber, toNumber)
 
 newtype Perm = Perm { r :: Boolean, w :: Boolean, x :: Boolean }

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -17,8 +17,8 @@ import Data.Char (Char(), charString)
 import Data.String (toCharArray)
 import Data.Function
 
-data Perm = Perm { r :: Boolean, w :: Boolean, x :: Boolean }
-data Perms = Perms { u :: Perm, g :: Perm, o :: Perm }
+newtype Perm = Perm { r :: Boolean, w :: Boolean, x :: Boolean }
+newtype Perms = Perms { u :: Perm, g :: Perm, o :: Perm }
 
 none = Perm { r: false, w: false, x: false }
 r = Perm { r: true, w: false, x: false }

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -1,0 +1,78 @@
+module Node.FS.Perms
+  ( permsFromString
+  , permsToString
+  , permsToNum
+  , Perm()
+  , Perms()
+  ) where
+
+import Global (isNaN)
+import Data.Maybe (Maybe(..))
+import Data.Char (Char(), charString)
+import Data.String (toCharArray)
+import Data.Function
+
+data Perm = Perm { r :: Boolean, w :: Boolean, x :: Boolean }
+data Perms = Perms { u :: Perm, g :: Perm, o :: Perm }
+
+permsFromString :: String -> Maybe Perms
+permsFromString = _perms <<< toCharArray
+  where
+    _perms (u : g : o : []) =
+      mkPerms <$> permFromChar u
+              <*> permFromChar g
+              <*> permFromChar o
+    _perms _ = Nothing
+
+permFromChar :: Char -> Maybe Perm
+permFromChar = _perm <<< charString
+  where
+    _perm "0" = Just $ mkPerm false false false
+    _perm "1" = Just $ mkPerm false false true
+    _perm "2" = Just $ mkPerm false true  false
+    _perm "3" = Just $ mkPerm false true  true
+    _perm "4" = Just $ mkPerm true  false false
+    _perm "5" = Just $ mkPerm true  false true
+    _perm "6" = Just $ mkPerm true  true  false
+    _perm "7" = Just $ mkPerm true  true  true
+    _perm _   = Nothing
+
+mkPerm :: Boolean -> Boolean -> Boolean -> Perm
+mkPerm r w x = Perm { r: r, w: w, x: x }
+
+mkPerms :: Perm -> Perm -> Perm -> Perms
+mkPerms u g o = Perms { u: u, g: g, o: o }
+
+permToNum :: Perm -> Number
+permToNum (Perm { r = r, w = w, x = x }) =
+    (if r then 4 else 0)
+  + (if w then 2 else 0)
+  + (if x then 1 else 0)
+
+permToString :: Perm -> String
+permToString = show <<< permToNum
+
+permsToString :: Perms -> String
+permsToString (Perms { u = u, g = g, o = o }) =
+     "0"
+  ++ permToString u
+  ++ permToString g
+  ++ permToString o
+
+type Radix = Number
+
+foreign import parseInt "" :: Fn2 String Radix Number
+runParseInt :: String -> Radix -> Number
+runParseInt = runFn2 parseInt
+
+permsToNum :: Perms -> Number
+permsToNum p = runParseInt (permsToString p) 8
+
+instance showPerm :: Show Perm where
+  show (Perm { r = r, w = w, x = x }) =
+       (if r then "r" else "-")
+    ++ (if w then "w" else "-")
+    ++ (if x then "x" else "-")
+
+instance showPerms :: Show Perms where
+  show (Perms { u = u, g = g, o = o }) = show u ++ show g ++ show o

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -6,7 +6,7 @@ module Node.FS.Perms
   , Perms()
   ) where
 
-import Global (isNaN)
+import Global (readInt)
 import Data.Maybe (Maybe(..))
 import Data.Char (Char(), charString)
 import Data.String (toCharArray)
@@ -61,12 +61,8 @@ permsToString (Perms { u = u, g = g, o = o }) =
 
 type Radix = Number
 
-foreign import parseInt "" :: Fn2 String Radix Number
-runParseInt :: String -> Radix -> Number
-runParseInt = runFn2 parseInt
-
 permsToNum :: Perms -> Number
-permsToNum p = runParseInt (permsToString p) 8
+permsToNum p = readInt 8 $ permsToString p
 
 instance showPerm :: Show Perm where
   show (Perm { r = r, w = w, x = x }) =

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -2,7 +2,13 @@ module Node.FS.Perms
   ( permsFromString
   , permsToString
   , permsToNum
+  , none
+  , r
+  , w
+  , x
+  , mkPerms
   , Perms()
+  , Perm()
   ) where
 
 import Global (readInt)
@@ -13,6 +19,15 @@ import Data.Function
 
 data Perm = Perm { r :: Boolean, w :: Boolean, x :: Boolean }
 data Perms = Perms { u :: Perm, g :: Perm, o :: Perm }
+
+none = Perm { r: false, w: false, x: false }
+r = Perm { r: true, w: false, x: false }
+w = Perm { r: false, w: true, x: false }
+x = Perm { r: false, w: false, x: true }
+
+instance semigroupPerm :: Semigroup Perm where
+  (<>) (Perm { r = r0, w = w0, x = x0 }) (Perm { r = r1, w = w1, x = x1 }) =
+    Perm { r: r0 || r1, w: w0 || w1, x: x0 || x1  }
 
 permsFromString :: String -> Maybe Perms
 permsFromString = _perms <<< toCharArray

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -69,7 +69,7 @@ foreign import fs "var fs = require('fs');" ::
   { renameSync :: Fn2 FilePath FilePath Unit
   , truncateSync :: Fn2 FilePath Number Unit
   , chownSync :: Fn3 FilePath Number Number Unit
-  , chmodSync :: Fn2 FilePath Number Unit
+  , chmodSync :: Fn2 FilePath String Unit
   , statSync :: Fn1 FilePath StatsObj
   , linkSync :: Fn2 FilePath FilePath Unit
   , symlinkSync :: Fn3 FilePath FilePath String Unit
@@ -159,11 +159,11 @@ chown file uid gid = mkEff $ \_ -> runFn3
 -- Changes the permissions of a file.
 --
 chmod :: forall eff. FilePath
-                  -> Number
+                  -> Perms
                   -> Eff (fs :: FS, err :: Exception | eff) Unit
 
-chmod file mode = mkEff $ \_ -> runFn2
-  fs.chmodSync file mode
+chmod file perms = mkEff $ \_ -> runFn2
+  fs.chmodSync file (permsToString perms)
 
 -- |
 -- Gets file statistics.

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -248,7 +248,7 @@ rmdir file = mkEff $ \_ -> runFn1
 mkdir :: forall eff. FilePath
                   -> Eff (fs :: FS, err :: Exception | eff) Unit
 
-mkdir = flip mkdir' mkPerms (r <> w <> x) (r <> w <> x) (r <> w <> x)
+mkdir = flip mkdir' $ mkPerms (r <> w <> x) (r <> w <> x) (r <> w <> x)
 
 -- |
 -- Makes a new directory with the specified permissions.

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -248,7 +248,7 @@ rmdir file = mkEff $ \_ -> runFn1
 mkdir :: forall eff. FilePath
                   -> Eff (fs :: FS, err :: Exception | eff) Unit
 
-mkdir = flip mkdir' (fromJust $ permsFromString "777")
+mkdir = flip mkdir' mkPerms (r <> w <> x) (r <> w <> x) (r <> w <> x)
 
 -- |
 -- Makes a new directory with the specified permissions.

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -45,11 +45,13 @@ import Data.Time
 import Data.Either
 import Data.Function
 import Data.Maybe (Maybe(..))
+import Data.Maybe.Unsafe(fromJust)
 import Node.Buffer (Buffer(..), size)
 import Node.Encoding
 import Node.FS
 import Node.FS.Stats
 import Node.Path (FilePath())
+import Node.FS.Perms
 
 foreign import data FileDescriptor :: *
 
@@ -75,7 +77,7 @@ foreign import fs "var fs = require('fs');" ::
   , realpathSync :: forall cache. Fn2 FilePath { | cache } FilePath
   , unlinkSync :: Fn1 FilePath Unit
   , rmdirSync :: Fn1 FilePath Unit
-  , mkdirSync :: Fn2 FilePath Number Unit
+  , mkdirSync :: Fn2 FilePath String Unit
   , readdirSync :: Fn1 FilePath [FilePath]
   , utimesSync :: Fn3 FilePath Number Number Unit
   , readFileSync :: forall a opts. Fn2 FilePath { | opts } a
@@ -246,17 +248,17 @@ rmdir file = mkEff $ \_ -> runFn1
 mkdir :: forall eff. FilePath
                   -> Eff (fs :: FS, err :: Exception | eff) Unit
 
-mkdir = flip mkdir' 777
+mkdir = flip mkdir' (fromJust $ permsFromString "777")
 
 -- |
 -- Makes a new directory with the specified permissions.
 --
 mkdir' :: forall eff. FilePath
-                   -> Number
+                   -> Perms
                    -> Eff (fs :: FS, err :: Exception | eff) Unit
 
-mkdir' file mode = mkEff $ \_ -> runFn2
-  fs.mkdirSync file mode
+mkdir' file perms = mkEff $ \_ -> runFn2
+  fs.mkdirSync file (permsToString perms)
 
 -- |
 -- Reads the contents of a directory.


### PR DESCRIPTION
This allows for zero-padded modes, such as e.g. 0777, which is the default for directories.

This is in line with the javascript version which takes a string.