### PR TITLE
Add `fstat` and `lstat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ chmod :: forall eff. FilePath -> Number -> Callback eff Unit -> Eff (fs :: FS | 
 stat :: forall eff. FilePath -> Callback eff Stats -> Eff (fs :: FS | eff) Unit
 ```
 
+#### `fstat`
+
+``` purescript
+fstat :: forall eff. FilePath -> Callback eff Stats -> Eff (fs :: FS | eff) Unit
+```
+
+
+#### `lstat`
+
+``` purescript
+lstat :: forall eff. FilePath -> Callback eff Stats -> Eff (fs :: FS | eff) Unit
+```
+
+
 #### `link`
 
 ``` purescript
@@ -365,6 +379,20 @@ chmod :: forall eff. FilePath -> Number -> Eff (err :: Exception, fs :: FS | eff
 ``` purescript
 stat :: forall eff. FilePath -> Eff (err :: Exception, fs :: FS | eff) Stats
 ```
+
+#### `lstat`
+
+``` purescript
+lstat :: forall eff. FilePath -> Eff (err :: Exception, fs :: FS | eff) Stats
+```
+
+
+#### `fstat`
+
+``` purescript
+fstat :: forall eff. FilePath -> Eff (err :: Exception, fs :: FS | eff) Stats
+```
+
 
 #### `link`
 

--- a/src/Node/FS/Async.purs
+++ b/src/Node/FS/Async.purs
@@ -5,6 +5,8 @@ module Node.FS.Async
   , chown
   , chmod
   , stat
+  , lstat
+  , fstat
   , link
   , symlink
   , readlink
@@ -63,6 +65,8 @@ foreign import fs "var fs = require('fs');" ::
   , chown :: Fn4 FilePath Number Number (JSCallback Unit) Unit
   , chmod :: Fn3 FilePath Number (JSCallback Unit) Unit
   , stat :: Fn2 FilePath (JSCallback StatsObj) Unit
+  , lstat :: Fn2 FilePath (JSCallback StatsObj) Unit
+  , fstat :: Fn2 FilePath (JSCallback StatsObj) Unit
   , link :: Fn3 FilePath FilePath (JSCallback Unit) Unit
   , symlink :: Fn4 FilePath FilePath String (JSCallback Unit) Unit
   , readlink :: Fn2 FilePath (JSCallback FilePath) Unit
@@ -142,6 +146,20 @@ stat :: forall eff. FilePath
 
 stat file cb = mkEff $ \_ -> runFn2
   fs.stat file (handleCallback $ cb <<< (<$>) Stats)
+
+fstat :: forall eff. FilePath
+                 -> Callback eff Stats
+                 -> Eff (fs :: FS | eff) Unit
+
+fstat file cb = mkEff $ \_ -> runFn2
+  fs.fstat file (handleCallback $ cb <<< (<$>) Stats)
+
+lstat :: forall eff. FilePath
+                 -> Callback eff Stats
+                 -> Eff (fs :: FS | eff) Unit
+
+lstat file cb = mkEff $ \_ -> runFn2
+  fs.lstat file (handleCallback $ cb <<< (<$>) Stats)
 
 -- |
 -- Creates a link to an existing file.

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -4,6 +4,8 @@ module Node.FS.Sync
   , chown
   , chmod
   , stat
+  , lstat
+  , fstat
   , link
   , symlink
   , readlink
@@ -69,6 +71,8 @@ foreign import fs "var fs = require('fs');" ::
   , chownSync :: Fn3 FilePath Number Number Unit
   , chmodSync :: Fn2 FilePath Number Unit
   , statSync :: Fn1 FilePath StatsObj
+  , lstatSync :: Fn1 FilePath StatsObj
+  , fstatSync :: Fn1 FilePath StatsObj
   , linkSync :: Fn2 FilePath FilePath Unit
   , symlinkSync :: Fn3 FilePath FilePath String Unit
   , readlinkSync :: Fn1 FilePath FilePath
@@ -171,6 +175,18 @@ stat :: forall eff. FilePath
 
 stat file = return $ Stats $ runFn1
   fs.statSync file
+
+lstat :: forall eff. FilePath
+                 -> Eff (fs :: FS, err :: Exception | eff) Stats
+
+lstat file = return $ Stats $ runFn1
+  fs.lstatSync file
+
+fstat :: forall eff. FilePath
+                 -> Eff (fs :: FS, err :: Exception | eff) Stats
+
+fstat file = return $ Stats $ runFn1
+  fs.fstatSync file
 
 -- |
 -- Creates a link to an existing file.


### PR DESCRIPTION
I am porting my copying library [kopeer](https://github.com/felixschl/kopeer) to purescript just for fun and found that `lstat` was missing from this project. It's the same signature as `stat` but the behaviour is slightly different, so I literally copied and pasted the implementation. The docs are [here](https://nodejs.org/api/all.html#all_fs_lstat_path_callback).

I could clean up the implementation by writing an internal function that takes one of `fs.stat`, `fs.lstat` or `fs.fstat` as a parameter and express the implementations in terms of that, if that's preferred.
