### PR TITLE
Fix badly behaved Show instance for SymlinkType

### DIFF
--- a/src/Node/FS.purs
+++ b/src/Node/FS.purs
@@ -12,10 +12,20 @@ foreign import data FS :: !
 --
 data SymlinkType = FileLink | DirLink | JunctionLink
 
+-- |
+-- Convert a `SymlinkType` to a `String` expected by the Node.js filesystem
+-- API.
+--
+symlinkTypeToNode :: SymlinkType -> String
+symlinkTypeToNode ty = case ty of
+  FileLink -> "file"
+  DirLink -> "dir"
+  JunctionLink -> "junction"
+
 instance showSymlinkType :: Show SymlinkType where
-  show FileLink     = "file"
-  show DirLink      = "dir"
-  show JunctionLink = "junction"
+  show FileLink     = "FileLink"
+  show DirLink      = "DirLink"
+  show JunctionLink = "JunctionLink"
 
 instance eqSymlinkType :: Eq SymlinkType where
   eq FileLink     FileLink     = true

--- a/src/Node/FS/Async.purs
+++ b/src/Node/FS/Async.purs
@@ -157,7 +157,7 @@ symlink :: forall eff. FilePath
                     -> Eff (fs :: FS | eff) Unit
 
 symlink src dest ty cb = mkEff $ \_ -> runFn4
-  fs.symlink src dest (show ty) (handleCallback cb)
+  fs.symlink src dest (symlinkTypeToNode ty) (handleCallback cb)
 
 -- |
 -- Reads the value of a symlink.

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -167,7 +167,7 @@ symlink :: forall eff. FilePath
                     -> Eff (fs :: FS, err :: EXCEPTION | eff) Unit
 
 symlink src dst ty = mkEff $ \_ -> runFn3
-  fs.symlinkSync src dst (show ty)
+  fs.symlinkSync src dst (symlinkTypeToNode ty)
 
 -- |
 -- Reads the value of a symlink.


### PR DESCRIPTION
So as not to overload the `Show` type class with lots of different meanings. See also https://github.com/purescript-node/purescript-node-fs/pull/22/files#r44604070

This probably ought to be considered a breaking change, although not a severe one, as I highly doubt anyone is depending on this behaviour.