### PR TITLE
updated docs, fixed redundant/unused import warnings

### DIFF
--- a/docs/Node/FS.md
+++ b/docs/Node/FS.md
@@ -34,8 +34,8 @@ data FileFlags
 
 ##### Instances
 ``` purescript
-instance showFileFlags :: Show FileFlags
-instance eqFileFlags :: Eq FileFlags
+Show FileFlags
+Eq FileFlags
 ```
 
 #### `fileFlagsToNode`
@@ -90,8 +90,8 @@ Symlink varieties.
 
 ##### Instances
 ``` purescript
-instance showSymlinkType :: Show SymlinkType
-instance eqSymlinkType :: Eq SymlinkType
+Show SymlinkType
+Eq SymlinkType
 ```
 
 #### `symlinkTypeToNode`

--- a/docs/Node/FS/Perms.md
+++ b/docs/Node/FS/Perms.md
@@ -23,10 +23,10 @@ intersection respectively.
 
 ##### Instances
 ``` purescript
-instance eqPerm :: Eq Perm
-instance ordPerm :: Ord Perm
-instance showPerm :: Show Perm
-instance semiringPerm :: Semiring Perm
+Eq Perm
+Ord Perm
+Show Perm
+Semiring Perm
 ```
 
 #### `none`
@@ -84,9 +84,9 @@ file owner, the group, and any other users.
 
 ##### Instances
 ``` purescript
-instance eqPerms :: Eq Perms
-instance ordPerms :: Ord Perms
-instance showPerms :: Show Perms
+Eq Perms
+Ord Perms
+Show Perms
 ```
 
 #### `permsFromString`

--- a/docs/Node/FS/Stats.md
+++ b/docs/Node/FS/Stats.md
@@ -17,7 +17,7 @@ Stats wrapper to provide a usable interface to the underlying properties and met
 
 ##### Instances
 ``` purescript
-instance showStats :: Show Stats
+Show Stats
 ```
 
 #### `isFile`

--- a/src/Node/FS/Async.purs
+++ b/src/Node/FS/Async.purs
@@ -43,7 +43,6 @@ import Data.Maybe
 import Data.Nullable
 import Node.Buffer (Buffer(), BUFFER(), size)
 import Data.Int (round)
-import Data.Maybe.Unsafe (fromJust)
 import Node.Encoding
 import Node.FS
 import Node.FS.Stats

--- a/src/Node/FS/Perms.purs
+++ b/src/Node/FS/Perms.purs
@@ -18,7 +18,7 @@ import Data.Maybe (Maybe(..), isNothing)
 import Data.Maybe.Unsafe (fromJust)
 import Data.Char (fromCharCode)
 import Data.String (toCharArray, joinWith, drop, charAt, indexOf)
-import Data.Int (fromNumber, toNumber)
+import Data.Int (fromNumber)
 
 -- | A `Perm` value specifies what is allowed to be done with a particular
 -- | file by a particular class of user &mdash; that is, whether it is

--- a/src/Node/FS/Sync.purs
+++ b/src/Node/FS/Sync.purs
@@ -36,7 +36,6 @@ import Control.Monad.Eff
 import Control.Monad.Eff.Exception
 import Data.Date
 import Data.Time
-import Data.Either
 import Data.Function
 import Data.Nullable (Nullable(), toNullable)
 import Data.Int (round)


### PR DESCRIPTION
With compiler v 0.7.6.1 there were a few warnings that I've fixed.