### PR TITLE
Add stdin, stdout, stderr :: FileDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- Add `stdin, stdout, stderr :: FileDescriptor` (#65 by @jamesdbrock)
+
 Bugfixes:
 
 Other improvements:

--- a/src/Node/FS.purs
+++ b/src/Node/FS.purs
@@ -1,5 +1,8 @@
 module Node.FS
   ( FileDescriptor(..)
+  , stdin
+  , stdout
+  , stderr
   , FileFlags(..)
   , FileMode(..)
   , SymlinkType(..)
@@ -12,8 +15,18 @@ module Node.FS
   ) where
 
 import Prelude
+import Unsafe.Coerce (unsafeCoerce)
 
 foreign import data FileDescriptor :: Type
+
+stdin :: FileDescriptor
+stdin = unsafeCoerce 0
+
+stdout :: FileDescriptor
+stdout = unsafeCoerce 1
+
+stderr :: FileDescriptor
+stderr = unsafeCoerce 2
 
 data FileFlags = R | R_PLUS | RS | RS_PLUS
                | W | WX | W_PLUS | WX_PLUS


### PR DESCRIPTION
**Description of the change**

Add `stdin, stdout, stderr :: FileDescriptor`.

The only way currently to get these file descriptors that I can see is something like

```purescript
stdin <- fdOpen "/dev/stdin" R Nothing
```

and that’s really not the same.

It’s also possible to do

```purescript
foreign import stdin :: FileDescriptor
```

```javascript
export const stdin = process.stdin.fd;
```

but I don’t really see any advantage to that.

I’ve tested this locally and it seems correct. It’s not obvious to me what the best way to write CI tests for this is. If you think this PR is a good idea then let’s talk about how to write the CI tests.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
