### PR TITLE
Add rmdir', rm, rm'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Breaking changes:
 
 New features:
 
+- Update rmdir' to take options arg
+- Added rm and rm' version with and without options arg
+
 Bugfixes:
 
 Other improvements:

--- a/src/Node/FS/Async.js
+++ b/src/Node/FS/Async.js
@@ -10,6 +10,7 @@ export {
   realpath as realpathImpl,
   unlink as unlinkImpl,
   rmdir as rmdirImpl,
+  rm as rmImpl,
   mkdir as mkdirImpl,
   readdir as readdirImpl,
   utimes as utimesImpl,

--- a/src/Node/FS/Sync.js
+++ b/src/Node/FS/Sync.js
@@ -10,6 +10,7 @@ export {
   realpathSync as realpathSyncImpl,
   unlinkSync as unlinkSyncImpl,
   rmdirSync as rmdirSyncImpl,
+  rmSync as rmSyncImpl,
   mkdirSync as mkdirSyncImpl,
   readdirSync as readdirSyncImpl,
   utimesSync as utimesSyncImpl,


### PR DESCRIPTION
**Description of the change**

Add options to rmdir', rm, rm'

https://nodejs.org/api/fs.html#fspromisesrmpath-options

Changes:

- Update `rmdir'` to take options arg
- Added `rm` and `rm'`  version with and witout options arg

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
