### PR TITLE
Remove redundant StatsObj methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 
+- Remove redundant/impure `StatsObj` methods (#72 by @ptrfrncsmrph)
+
 New features:
 
 Bugfixes:

--- a/src/Node/FS/Stats.purs
+++ b/src/Node/FS/Stats.purs
@@ -15,7 +15,7 @@ module Node.FS.Stats
 
 import Prelude
 import Data.DateTime (DateTime)
-import Data.Function.Uncurried (Fn2, Fn0, runFn2)
+import Data.Function.Uncurried (Fn2, runFn2)
 import Data.JSDate (JSDate, toDateTime)
 import Data.Maybe (fromJust)
 import Partial.Unsafe (unsafePartial)
@@ -32,12 +32,6 @@ type StatsObj =
   , atime :: JSDate
   , mtime :: JSDate
   , ctime :: JSDate
-  , isFile :: Fn0 Boolean
-  , isDirectory :: Fn0 Boolean
-  , isBlockDevice :: Fn0 Boolean
-  , isCharacterDevice :: Fn0 Boolean
-  , isFIFO :: Fn0 Boolean
-  , isSocket :: Fn0 Boolean
   }
 
 -- | Stats wrapper to provide a usable interface to the underlying properties and methods.


### PR DESCRIPTION
Resolves #71

**Description of the change**

The `StatsObj` methods are not pure (require `this` context be preserved) and are redundant anyways (there are standalone functions `Stats -> Boolean` for each method). This deletes them from `StatsObj`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
