### PR TITLE
Add bower to dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Bugfixes:
 
 Other improvements:
 
+- (Internal) Added bower to dev dependencies (#84 by @artemisSystem)
+
 ## [v9.1.0](https://github.com/purescript-node/purescript-node-fs/releases/tag/v9.1.0) - 2023-07-26
 
 Bugfixes:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "pulp test -- --censor-lib"
   },
   "devDependencies": {
+    "bower": "^1.8.14",
     "eslint": "^7.15.0",
     "pulp": "16.0.0-0",
     "purescript-psa": "^0.8.2",


### PR DESCRIPTION
**Description of the change**

Adds bower to the npm dev dependencies, given it's used for retrieving dependencies.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- ~~[] Linked any existing issues or proposals that this pull request should close~~
- ~~[] Updated or added relevant documentation~~
