### PR TITLE
add `lstat` to `Node.FS.Aff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Breaking changes:
 
 New features:
 
+- Add `lstat` to `Node.FS.Aff` (#85 by @artemisSystem)
+
 Bugfixes:
 
 Other improvements:

--- a/src/Node/FS/Aff.purs
+++ b/src/Node/FS/Aff.purs
@@ -10,6 +10,7 @@ module Node.FS.Aff
   , chown
   , chmod
   , stat
+  , lstat
   , link
   , symlink
   , readlink
@@ -146,6 +147,12 @@ chmod = toAff2 A.chmod
 -- |
 stat :: FilePath -> Aff Stats
 stat = toAff1 A.stat
+
+-- | Gets file or symlink statistics. `lstat` is identical to `stat`, except
+-- | that if the `FilePath` is a symbolic link, then the link itself is stat-ed,
+-- | not the file that it refers to.
+lstat :: FilePath -> Aff Stats
+lstat = toAff1 A.lstat
 
 -- |
 -- | Creates a link to an existing file.


### PR DESCRIPTION
**Description of the change**

add `lstat` to the Aff module, as it was missing.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- ~~[] Linked any existing issues or proposals that this pull request should close~~
- ~~[] Updated or added relevant documentation~~
- ~~[] Added a test for the contribution (if applicable)~~
